### PR TITLE
feat: Add character 'Hardcase'

### DIFF
--- a/src/Reference.AzurePipelines/StarWarsNames.cs
+++ b/src/Reference.AzurePipelines/StarWarsNames.cs
@@ -54,6 +54,7 @@ namespace StarWars.Names
             "Grand Moff Tarkin",
             "Greedo",
             "Han Solo",
+            "Hardcase",
             "IG 88",
             "Jabba The Hutt",
             "Jacen Solo",


### PR DESCRIPTION
Hardcase is a mentally unstable Clone Trooper. Hardcase participated in
the search for General Grievous on Saleucami. Hardcase also participated
in the Umbara Campaign, sacrificing his life to destroy a droid supply
trip.