### PR TITLE
chore(build): DOTNET_ROOT no longer needs to be set for macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,9 +81,6 @@ jobs:
       macOS:
         imageName: 'macOS-latest'
         name: 'macOS'
-        # Need to set the DOTNET_ROOT for macOS as dotnet is not installed in the default location.
-        # For details, see https://github.com/dotnet/cli/issues/9114
-        DOTNET_ROOT: /Users/vsts/.dotnet
       Windows:
         imageName: 'windows-latest'
         name: 'windows'


### PR DESCRIPTION
This should suppress the following warning on build:

##[warning]Overwriting readonly task variable 'DOTNET_ROOT'. This behavior will be disabled in the future. See https://github.com/microsoft/azure-pipelines-yaml/blob/master/design/readonly-variables.md for details.